### PR TITLE
Fix/gpg not found error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ workflows:
       - validate_infrastructure:
           filters:
             branches:
-              only: fix/gpg-error
+              only: staging
       - approve:
           description: "Approve"
           type: approval


### PR DESCRIPTION
Validates the downloaded Terraform zip file by comparing the expected and downloaded SHA256 checksums. If they don't match, an error message is printed, and the script exits with an exit code of 1. Ignored verification of the digital signature as `gpg` package not available on the executor instance.