### PR TITLE
Generate passport id according to community

### DIFF
--- a/pallets/passport/src/lib.rs
+++ b/pallets/passport/src/lib.rs
@@ -98,7 +98,7 @@ pub mod pallet {
 	/// Stores the `PassportId` that is going to be used for the next passport.
 	/// This gets incremented whenever a new passport is created.
 	#[pallet::storage]
-	pub type NextPassportId<T: Config> = StorageValue<_, T::PassportId, OptionQuery>;
+	pub type NextPassportId<T: Config> = StorageMap<_, Twox64Concat, T::CommunityId, T::PassportId, OptionQuery>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -156,7 +156,7 @@ pub mod pallet {
 			let maybe_passport = Passports::<T>::get(community_id, &origin);
 			ensure!(maybe_passport.is_some() == false, Error::<T>::PassportAlreadyMinted);
 
-			let passport_id = NextPassportId::<T>::get().unwrap_or(T::PassportId::initial_value());
+			let passport_id = NextPassportId::<T>::get(community_id).unwrap_or(T::PassportId::initial_value());
 
 			let passport_details =
 				PassportDetails { id: passport_id, address: None, stamps: None, avatar: None };
@@ -164,7 +164,7 @@ pub mod pallet {
 			<Passports<T>>::insert(community_id, &origin, passport_details);
 
 			let next_id = passport_id.increment();
-			NextPassportId::<T>::set(Some(next_id));
+			NextPassportId::<T>::insert(community_id, next_id);
 
 			Self::deposit_event(Event::MintedPassport(passport_id, origin));
 			Ok(())

--- a/pallets/passport/src/tests.rs
+++ b/pallets/passport/src/tests.rs
@@ -51,8 +51,14 @@ fn mint_passport_works_for_founder() {
 	new_test_ext().execute_with(|| {
 		create_community();
 		assert_ok!(Passport::mint(RuntimeOrigin::signed(1), 0));
-
-		assert!(Passports::<Test>::get(0, 1).is_some());
+		assert_eq!(Passports::<Test>::get(0, 1).unwrap().id, 0);
+		assert_ok!(Passport::mint(RuntimeOrigin::signed(2), 0));
+		assert_eq!(Passports::<Test>::get(0, 2).unwrap().id, 1);
+		create_community();
+		assert_ok!(Passport::mint(RuntimeOrigin::signed(1), 1));
+		assert_eq!(Passports::<Test>::get(1, 1).unwrap().id, 0);
+		assert_ok!(Passport::mint(RuntimeOrigin::signed(2), 1));
+		assert_eq!(Passports::<Test>::get(1, 2).unwrap().id, 1);
 	});
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 104,
+	spec_version: 105,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
https://app.asana.com/0/1205016363348911/1205002220401038/f

This PR will update the passport to feature so that every community has its own passport numbering. Currently the passport id is unified throughout the ecosystem. We need to make the passport id link with community Id so that every community have its own passport Id series.