### PR TITLE
contrib: add convenience scripts

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,8 @@
+# The contrib directory
+
+The contrib directory is used as an unorganized (or, at best, lightly
+organized) bin of various useful things contributed by either the core
+developers, the community, or some time travellers just casually passing by.
+
+The scripts in this directory and its sub-directories are provided as-is and
+aren't necessarily actively maintained by the Jur Engineering.

--- a/contrib/buildsystem/BUILD_TRICKS.md
+++ b/contrib/buildsystem/BUILD_TRICKS.md
@@ -1,0 +1,41 @@
+# Speed builds up
+
+There are a few things that one could do to speed up
+the builds.
+
+### Caching: sccache
+
+Firstly, install sccache:
+
+```shell
+cargo install sccache
+```
+
+Set the RUSTC_WRAPPER environment variable:
+
+```shell
+echo "export RUSTC_WRAPPER=sccache" >> ~/.cargo/env
+```
+
+### Turn fsync() syscalls into no-ops: libeatmydata
+
+Additionally, one could install [libeatmydata](https://www.flamingspork.com/projects/libeatmydata/).
+
+It is distributed by the vast majority of Linux distributions. For instance, on Debian
+one could do:
+
+```shell
+sudo apt install libeatmydata
+```
+
+On MacOS, it could be found in Homebrew's taps:
+
+```shell
+brew install libeatmydata
+```
+
+Finally, just wrap `cargo build` calls with the program `eatmydata`:
+
+```shell
+eatmydata cargo build --dev
+```

--- a/contrib/direnv.envrc
+++ b/contrib/direnv.envrc
@@ -1,0 +1,19 @@
+# This file is a direnv configuration template for the jur-node
+# directory. It is meant to give visibility to and illustrate the
+# usage of environment variables when working within the jur-node's
+# sources root directory.
+#
+# This file should be copied into the root directory, renamed to
+# .envrc, and modified as needed.
+#
+# Let's start by loading the cargo environment file.
+. ~/.cargo/env
+
+# Uncomment the following if you want to disable the git pre-commit hook.
+# JUR_NODE_GIT_PRECOMMIT=off
+
+# Alternatively, commenting the following line would lead to the same outcome.
+git config config.hooksPaths || git config config.hooksPaths contrib/githooks
+
+# The next line enable clippy, if installed.
+JUR_NODE_GIT_PRECOMMIT_FEATS=clippy

--- a/contrib/githooks/README.md
+++ b/contrib/githooks/README.md
@@ -1,0 +1,30 @@
+# Git hooks
+
+Installation:
+
+```shell
+git config core.hooksPath contrib/githooks
+```
+
+## pre-commit
+
+The hook automatically runs `cargo fmt`, to correctly format the
+`.rs` files included in the commit, provided that rust toolchain's
+program are installed and available in the user's search `$PATH`
+environment variable.
+
+### Environment variables
+
+The pre-commit hook can be switched off by changing the value held by the
+environvement variable `JUR_NODE_GIT_PRECOMMIT` as shown in the following example:
+
+```shell
+export JUR_NODE_GIT_PRECOMMIT=off
+```
+
+The hook also runs `cargo clippy` if the environment variable
+`JUR_NODE_GIT_PRECOMMIT_FEATS` contains the word `clippy`:
+
+```shell
+export JUR_NODE_GIT_PRECOMMIT_FEATS=clippy
+```

--- a/contrib/githooks/pre-commit
+++ b/contrib/githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+f_echo_stderr() {
+  echo $@ >&2
+}
+
+f_exit_success() {
+  [ x"$@" != "x" ] && f_echo_stderr $@ || exit 0
+}
+trap f_exit_success EXIT
+
+
+case "${JUR_NODE_GIT_PRECOMMIT}" in
+  0|no|false|off) exit 0 ;;
+  *) : ;;
+esac
+
+# if [ "$(git diff --cached --name-only -- '*.rs')" = "" ]; then
+#   f_echo_stderr "No changes to source files are staged, exiting."
+#   exit 0
+# fi
+
+cargo fmt -- --check
+
+[[ "${JUR_NODE_GIT_PRECOMMIT_FEATS}" =~ "clippy" ]] && \
+  cargo clippy --version &>/dev/null && cargo clippy
+
+exit 0


### PR DESCRIPTION
contrib/direnv.envrc: direnv's basic configuation.
Developers should just copy it into the repository's
root directory in order to activate it with direnv.

contrib/buildystem: tricks,scripts&tips about improving
buildsystem's performance.

contrib/githooks: git's pre-commit hook that checks
and fixes code formatting.