### PR TITLE
ci: speed up builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,5 +128,13 @@ jobs:
         path: |
           ~/.cargo/
           ./target/
+    - name: cargo test cache
+      id: cache-cargo-test
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+        path: |
+          ~/.cargo/
+          ./target/
     - name: Test
       run: SKIP_WASM_BUILD= cargo test --workspace --features runtime-benchmarks


### PR DESCRIPTION
Cache build artifacts to save resources.

Run builds in parallel whenever possible.